### PR TITLE
Lib should not have allowbakup attribute

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-sdk tools:overrideLibrary="android.support.customtabs" android:minSdkVersion="15"/>
     <application
-        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">


### PR DESCRIPTION
Remove android:allowBackup="true" from AndroidManifest file as it is giving Manifest merger issues with the application manifest file and the other libraries Manifest file. It's not necessary for your lib.
Error seems like: "Manifest merger failed : Attribute application@allowBackup value=(false)".

Thank you very much for the great lib.